### PR TITLE
카테고리 페이지, 검색페이지

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -5,11 +5,6 @@ const client = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
 });
 
-export const getProducts = async () => {
-  const res = await client.get('/products');
-  return res.data;
-};
-
 export const postProducts = async (
   title: string,
   categoryId: number,
@@ -42,6 +37,15 @@ export const postProducts = async (
 
 export const getProductCategory = async () => {
   const res = await client.get(`/products/categories`);
+  return res.data;
+};
+
+export const getProducts = async (keyword?: string) => {
+  const res = await client.get('/products', {
+    params: {
+      searchWord: keyword,
+    },
+  });
   return res.data;
 };
 

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -40,6 +40,11 @@ export const postProducts = async (
   return res.data;
 };
 
+export const getProductCategory = async () => {
+  const res = await client.get(`/products/categories`);
+  return res.data;
+};
+
 export const postSignUp = async (
   email: string,
   password: string,

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -40,10 +40,11 @@ export const getProductCategory = async () => {
   return res.data;
 };
 
-export const getProducts = async (keyword?: string) => {
+export const getProducts = async (searchWord?: string, categoryId?: number) => {
   const res = await client.get('/products', {
     params: {
-      searchWord: keyword,
+      categoryId,
+      searchWord,
     },
   });
   return res.data;

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -40,11 +40,11 @@ export const getProductCategory = async () => {
   return res.data;
 };
 
-export const getProducts = async (searchWord?: string, categoryId?: number) => {
+export const getProducts = async (searchWord?: string, categoryId?: string) => {
   const res = await client.get('/products', {
     params: {
-      categoryId,
       searchWord,
+      categoryIds: categoryId,
     },
   });
   return res.data;

--- a/src/styles/templates/search/search.scss
+++ b/src/styles/templates/search/search.scss
@@ -8,64 +8,16 @@
       border: 0;
       background: transparent;
       &__wrap {
+        @include flex();
         width: 100%;
-        height: 60%;
         background: #efefef;
         padding: 0 17px;
         border-radius: 5px;
         overflow: hidden;
-      }
-    }
-    &__container {
-      > div + div {
-        border-top: 1px solid #a5a5a5;
-      }
-    }
-    &__list {
-      display: flex;
-      column-gap: 24px;
-      width: 100%;
-      height: 156px;
-      padding: 20px 15px;
-      &__img {
-        flex-shrink: 0;
-        position: relative;
-        width: 119px;
-        height: 119px;
-        border-radius: 5px;
-        border: 1px solid #000;
-        background: #cdcdcd;
-        overflow: hidden;
-        box-shadow: 0 4px 4px rgba(#000, 0.25);
-        > img {
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-          width: 119px;
-        }
-      }
-      &__content {
-        @include flex($direction: column, $justify: space-between);
-        width: 100%;
-        .title {
-          @include font(20px);
-        }
-        .place {
-          @include font(18px, 400, #868686);
-        }
-        .price {
-          @include font(18px, 400, #000);
-        }
-        .like {
-          @include flex($justify: flex-end);
-          .heart {
-            width: 23px;
-            height: 23px;
-          }
-          &Counter {
-            @include font(18px);
-          }
+
+        input {
+          padding: 0;
+          font-size: 14px;
         }
       }
     }

--- a/src/templates/category/categoryPage.tsx
+++ b/src/templates/category/categoryPage.tsx
@@ -1,22 +1,35 @@
-import Header from '@/components/header';
+'use client';
 
+import { getProductCategory } from '@/api/service';
+import Header from '@/components/header';
 import '@/styles/templates/category/category.scss';
+import { AXIOSResponse } from '@/types/interface';
+import { useEffect, useState } from 'react';
+
+type CategoryType = {
+  id: number;
+  name: string;
+};
 
 export default function CategoryPage() {
+  const [category, setCategory] = useState<CategoryType[]>([]);
+  useEffect(() => {
+    const fetchData = async () => {
+      const res: AXIOSResponse<CategoryType[]> = await getProductCategory();
+      if (res.statusCode === 200) {
+        setCategory(res.data);
+      }
+    };
+
+    fetchData();
+  }, []);
   return (
     <div id="categoryPage">
       <Header goBack={true} title={'카테고리'} border={true} />
       <div className="category__content">
-        <div>디지털기기</div>
-        <div>생활가전</div>
-        <div>가구/인테리어</div>
-        <div>유아동</div>
-        <div>생활/가공식품</div>
-        <div>유아도서</div>
-        <div>여성의류</div>
-        <div>남성패션/잡화</div>
-        <div>게임/취미</div>
-        <div>뷰티/미용</div>
+        {category.map((item: CategoryType) => (
+          <div>{item.name}</div>
+        ))}
       </div>
     </div>
   );

--- a/src/templates/category/categoryPage.tsx
+++ b/src/templates/category/categoryPage.tsx
@@ -3,7 +3,8 @@
 import { getProductCategory, getProducts } from '@/api/service';
 import Header from '@/components/header';
 import '@/styles/templates/category/category.scss';
-import { AXIOSResponse, IProduct } from '@/types/interface';
+import { AXIOSResponse } from '@/types/interface';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 type CategoryType = {
@@ -13,11 +14,11 @@ type CategoryType = {
 
 export default function CategoryPage() {
   const [category, setCategory] = useState<CategoryType[]>([]);
+  const router = useRouter();
   useEffect(() => {
     const fetchData = async () => {
       const res: AXIOSResponse<CategoryType[]> = await getProductCategory();
       if (res.statusCode === 200) {
-        console.log(res.data);
         setCategory(res.data);
       }
     };
@@ -25,12 +26,8 @@ export default function CategoryPage() {
     fetchData();
   }, []);
 
-  const onClick = async (categoryId: number) => {
-    const res: AXIOSResponse<IProduct[]> = await getProducts(
-      undefined,
-      categoryId,
-    );
-    console.log(res);
+  const onClick = async (item: CategoryType) => {
+    router.push(`/main?category=${item.name}&categoryId=${item.id}`);
   };
   return (
     <div id="categoryPage">
@@ -39,7 +36,7 @@ export default function CategoryPage() {
         {category.map((item: CategoryType) => (
           <div
             onClick={() => {
-              onClick(item.id);
+              onClick(item);
             }}>
             {item.name}
           </div>

--- a/src/templates/category/categoryPage.tsx
+++ b/src/templates/category/categoryPage.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { getProductCategory } from '@/api/service';
+import { getProductCategory, getProducts } from '@/api/service';
 import Header from '@/components/header';
 import '@/styles/templates/category/category.scss';
-import { AXIOSResponse } from '@/types/interface';
+import { AXIOSResponse, IProduct } from '@/types/interface';
 import { useEffect, useState } from 'react';
 
 type CategoryType = {
@@ -17,18 +17,32 @@ export default function CategoryPage() {
     const fetchData = async () => {
       const res: AXIOSResponse<CategoryType[]> = await getProductCategory();
       if (res.statusCode === 200) {
+        console.log(res.data);
         setCategory(res.data);
       }
     };
 
     fetchData();
   }, []);
+
+  const onClick = async (categoryId: number) => {
+    const res: AXIOSResponse<IProduct[]> = await getProducts(
+      undefined,
+      categoryId,
+    );
+    console.log(res);
+  };
   return (
     <div id="categoryPage">
       <Header goBack={true} title={'카테고리'} border={true} />
       <div className="category__content">
         {category.map((item: CategoryType) => (
-          <div>{item.name}</div>
+          <div
+            onClick={() => {
+              onClick(item.id);
+            }}>
+            {item.name}
+          </div>
         ))}
       </div>
     </div>

--- a/src/templates/main/mainPage.tsx
+++ b/src/templates/main/mainPage.tsx
@@ -11,13 +11,20 @@ import { RxHamburgerMenu } from 'react-icons/rx';
 import Link from 'next/link';
 import Navbar from '@/components/navbar';
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 export default function MainPage() {
   const [data, setData] = useState<IProduct[]>([]);
+  const categoryParams = useSearchParams();
+  const category = categoryParams.get('category') || '전체';
+  const categoryId = categoryParams.get('categoryId') || undefined;
 
   useEffect(() => {
     const fetchData = async () => {
-      const res: AXIOSResponse<IProduct[]> = await getProducts();
+      const res: AXIOSResponse<IProduct[]> = await getProducts(
+        undefined,
+        categoryId,
+      );
       if (res.statusCode === 200) {
         setData(res.data);
       }
@@ -30,7 +37,7 @@ export default function MainPage() {
     <div id="mainPage">
       <header>
         <Header
-          title={'개발자님'}
+          title={category}
           border={true}
           button={
             <>

--- a/src/templates/search/searchPage.tsx
+++ b/src/templates/search/searchPage.tsx
@@ -1,50 +1,41 @@
-import Header from '@/components/header';
+'use client';
 
-import { AiOutlineHeart } from 'react-icons/ai';
+import { getProducts } from '@/api/service';
+import Header from '@/components/header';
+import ProductList from '@/components/productList';
 import '@/styles/templates/search/search.scss';
+import { AXIOSResponse, IProduct } from '@/types/interface';
+import { useEffect, useState } from 'react';
 
 export default function SearchPage() {
+  const [keyword, setKeyword] = useState<string>('');
+  const [data, setData] = useState<IProduct[]>([]);
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value);
+  };
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const res: AXIOSResponse<IProduct[]> = await getProducts(keyword);
+    if (res.statusCode === 200) {
+      setData(res.data);
+    }
+  };
   return (
     <div id="searchPage">
       <Header goBack={true} border={true}>
-        <label className="searchBar__wrap">
-          <input
-            className="searchBar"
-            type="text"
-            placeholder="우리동네에서 검색"
-          />
-        </label>
+        <form onSubmit={onSubmit}>
+          <label className="searchBar__wrap">
+            <input
+              className="searchBar"
+              type="text"
+              placeholder="검색어를 입력해주세요."
+              onChange={onChange}
+              value={keyword}
+            />
+          </label>
+        </form>
       </Header>
-      <div className="search__container">
-        <div className="search__list">
-          <div className="search__list__img">
-            <img src="https://via.placeholder.com/119x119" alt="임시이미지" />
-          </div>
-          <div className="search__list__content">
-            <div className="title">제목</div>
-            <div className="place">장소</div>
-            <div className="price">가격</div>
-            <div className="like">
-              <AiOutlineHeart className="heart heart--off" />
-              <span className="likeCounter">n</span>
-            </div>
-          </div>
-        </div>
-        <div className="search__list">
-          <div className="search__list__img">
-            <img src="https://via.placeholder.com/119x119" alt="임시이미지" />
-          </div>
-          <div className="search__list__content">
-            <div className="title">제목</div>
-            <div className="place">장소</div>
-            <div className="price">가격</div>
-            <div className="like">
-              <AiOutlineHeart className="heart heart--off" />
-              <span className="likeCounter">n</span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <ProductList data={data} />
     </div>
   );
 }


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #44 
## 작업 내용 (변경 사항)
- 카테고리 페이지
  - 임시 ui 삭제 완료
  - 클릭시 `console.log`로 데이터 읽어오기
- 검색 페이지
  - 실제 api 연동 후 `ProductList` 컴포넌트와 연결
  
## 스크린샷
| 검색페이지 | 카테고리페이지 |
|---|---|
|<img width="318" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/125979833/c518e56b-a87a-45e8-bb8f-28d671fc9cd4">|<img width="318" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/125979833/fb1f9169-1083-4443-b97f-9e87df543433">|
## 테스트 결과
- 카테고리 api 삭제된 데이터까지 모두 가져오는 이슈 존재합니다.
## 리뷰 요청 사항
- 해당 카테고리 클릭시 어느 url로 이동해야할지 모르겠어서 일단 콘솔에 결과 데이터 찍어놨습니다.
## Check list
- [ ] 테스트 통과
- [ ] 문서 업데이트
