### PR TITLE
Feature/#42 상세페이지 API 연결, 회원가입 API 에러처리 추가

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 const client = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  withCredentials: true,
 });
 
 export const getProducts = async () => {
@@ -55,15 +56,9 @@ export const postSignUp = async (
 };
 
 export const postAuth = async (email: string, password: string) => {
-  const res = await client.post(
-    '/login',
-    {
-      email: email,
-      password: password,
-    },
-    {
-      withCredentials: true,
-    },
-  );
+  const res = await client.post('/login', {
+    email: email,
+    password: password,
+  });
   return res;
 };

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -10,6 +10,15 @@ export const getProducts = async () => {
   return res.data;
 };
 
+export const getProductDetail = async (id: number) => {
+  const res = await client.get(`/products/${id}`, {
+    params: {
+      productId: id,
+    },
+  });
+  return res.data;
+};
+
 export const postProducts = async (
   title: string,
   categoryId: number,

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -87,3 +87,9 @@ export const getMyInfo = async () => {
   console.log(res);
   return res;
 };
+
+// 내 판매 상품 리스트 조회
+export const getMyProduct = async () => {
+  const res = await client.get('/myPage/products');
+  return res.data;
+};

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,8 +1,7 @@
-'use client'
+'use client';
 import MypagePage from '@/templates/mypage/mypagePage';
 
 export default function Mypage() {
-  console.log('test')
   return (
     <>
       <MypagePage />

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { ProductDetail } from '@/templates/product/productDetail';
+
+type Params = {
+  id: string;
+};
+
+export default function Page({ params }: { params: Params }) {
+  console.log(params);
+
+  return <ProductDetail />;
+}

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,12 +1,5 @@
-'use client';
 import { ProductDetail } from '@/templates/product/productDetail';
 
-type Params = {
-  id: string;
-};
-
-export default function Page({ params }: { params: Params }) {
-  console.log(params);
-
+export default function Page() {
   return <ProductDetail />;
 }

--- a/src/app/product/page.tsx
+++ b/src/app/product/page.tsx
@@ -1,9 +1,0 @@
-import { ProductDetail } from '@/templates/product/productDetail';
-
-export default function Product() {
-  return (
-    <>
-      <ProductDetail />
-    </>
-  );
-}

--- a/src/components/btn.tsx
+++ b/src/components/btn.tsx
@@ -1,6 +1,7 @@
+'use client';
 import React from 'react';
 import '@/styles/components/btn.scss';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 interface BtnProps {
   type: 'button' | 'submit' | 'reset';
@@ -17,6 +18,8 @@ export default function Btn({
   disabled,
   onClick,
 }: BtnProps) {
+  const router = useRouter();
+
   const buttonElement = (
     <div id="button">
       <button type={type} onClick={onClick} disabled={disabled}>
@@ -27,9 +30,9 @@ export default function Btn({
 
   // href가 있을 때만 Link 컴포넌트로 감싼다.
   return href ? (
-    <Link id="button" href={href}>
+    <div id="button" onClick={() => router.push(href)}>
       {buttonElement}
-    </Link>
+    </div>
   ) : (
     buttonElement
   );

--- a/src/components/productList.tsx
+++ b/src/components/productList.tsx
@@ -1,14 +1,15 @@
 import { IProduct } from '@/types/interface';
 import ProductItem from './productItem';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 export default function ProductList({ data }: { data: IProduct[] }) {
+  const router = useRouter();
   return (
     <ul className="products">
       {data?.map((product: IProduct) => (
-        <Link href={`/product/${product.id}`}>
+        <div onClick={() => router.push(`/product/${[product.id]}`)}>
           <ProductItem key={product.id} product={product} />
-        </Link>
+        </div>
       ))}
     </ul>
   );

--- a/src/styles/templates/home.scss
+++ b/src/styles/templates/home.scss
@@ -31,9 +31,10 @@
     text-align: center;
     padding-bottom: 1rem;
 
-    a {
+    div {
       color: $sub-color;
       padding-left: 0.5rem;
+      margin-top: 0.3rem;
     }
   }
 }

--- a/src/styles/templates/login/login.scss
+++ b/src/styles/templates/login/login.scss
@@ -31,7 +31,7 @@
       p {
         margin-top: 1.5rem;
       }
-      a {
+      div {
         color: $sub-color;
         margin-top: 0.5rem;
       }

--- a/src/templates/homePage.tsx
+++ b/src/templates/homePage.tsx
@@ -1,9 +1,11 @@
+'use client';
 import Btn from '@/components/btn';
 import '@/styles/templates/home.scss';
-import Link from 'next/link';
 import Header from '@/components/header';
+import { useRouter } from 'next/navigation';
 
 export default function HomePage() {
+  const router = useRouter();
   return (
     <>
       <Header />
@@ -18,7 +20,7 @@ export default function HomePage() {
           <Btn type="button" href="/signup" label="시작하기" />
           <div className="homePage__text--login">
             이미 계정이 있나요?
-            <Link href="/login">로그인</Link>
+            <div onClick={() => router.push('/login')}>로그인</div>
           </div>
         </footer>
       </div>

--- a/src/templates/login/loginPage.tsx
+++ b/src/templates/login/loginPage.tsx
@@ -2,7 +2,6 @@
 
 import Btn from '@/components/btn';
 import '@/styles/templates/login/login.scss';
-import Link from 'next/link';
 import Header from '@/components/header';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -64,7 +63,7 @@ export default function LoginPage() {
           />
           <div className="loginPage__text-pw">
             <p>비밀번호를 잊어버리셨나요?</p>
-            <Link href="/login">비밀번호 찾기</Link>
+            <div onClick={() => router.push('/login')}>비밀번호 찾기</div>
           </div>
         </footer>
       </div>

--- a/src/templates/main/addBtn.tsx
+++ b/src/templates/main/addBtn.tsx
@@ -1,10 +1,11 @@
-import Link from 'next/link';
 import '@/styles/templates/main/addBtn.scss';
+import { useRouter } from 'next/navigation';
 
 export default function AddBtn() {
+  const router = useRouter();
   return (
     <button className="addbutton">
-      <Link href="/write">+</Link>
+      <div onClick={() => router.push('/write')}>+</div>
     </button>
   );
 }

--- a/src/templates/main/mainPage.tsx
+++ b/src/templates/main/mainPage.tsx
@@ -8,7 +8,6 @@ import '@/styles/templates/main/main.scss';
 import AddBtn from './addBtn';
 import { AiOutlineSearch } from 'react-icons/ai';
 import { RxHamburgerMenu } from 'react-icons/rx';
-import Link from 'next/link';
 import Navbar from '@/components/navbar';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';

--- a/src/templates/main/mainPage.tsx
+++ b/src/templates/main/mainPage.tsx
@@ -11,9 +11,12 @@ import { RxHamburgerMenu } from 'react-icons/rx';
 import Link from 'next/link';
 import Navbar from '@/components/navbar';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function MainPage() {
   const [data, setData] = useState<IProduct[]>([]);
+
+  const router = useRouter();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -34,12 +37,12 @@ export default function MainPage() {
           border={true}
           button={
             <>
-              <Link href="search">
+              <div onClick={() => router.push('/search')}>
                 <AiOutlineSearch className="header__btn" />
-              </Link>
-              <Link href="category">
+              </div>
+              <div onClick={() => router.push('/category')}>
                 <RxHamburgerMenu className="header__btn" />
-              </Link>
+              </div>
             </>
           }
         />

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Btn from '@/components/btn';
 import Header from '@/components/header';
-import '@/styles/templates/product/ProductDetail.scss';
+import '@/styles/templates/product/productDetail.scss';
 import Link from 'next/Link';
 import { useEffect, useRef, useState } from 'react';
 import { AiOutlineHeart } from 'react-icons/ai';

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -33,6 +33,7 @@ type Product = {
 export const ProductDetail = () => {
   const router = useRouter();
   const id = usePathname().split('/')[2];
+
   const productId: number | any =
     typeof id === 'string' ? parseInt(id, 10) : undefined;
 
@@ -78,7 +79,6 @@ export const ProductDetail = () => {
       try {
         if (res2.statusCode === 200) {
           setMyProduct(res2.data);
-          console.log(res2.data);
         }
       } catch (error) {
         console.error(error);

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -1,9 +1,9 @@
 'use client';
-import { getProductDetail } from '@/api/service';
+import { getMyProduct, getProductDetail } from '@/api/service';
 import Btn from '@/components/btn';
 import Header from '@/components/header';
 import '@/styles/templates/product/productDetail.scss';
-import { AXIOSResponse } from '@/types/interface';
+import { AXIOSResponse, IProduct } from '@/types/interface';
 import { useRouter, usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { AiOutlineHeart } from 'react-icons/ai';
@@ -37,6 +37,7 @@ export const ProductDetail = () => {
     typeof id === 'string' ? parseInt(id, 10) : undefined;
 
   const [product, setProduct] = useState<Product | null>(null);
+  const [myProduct, setMyProduct] = useState<IProduct[]>([]);
 
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const menuRef = useRef<HTMLUListElement | null>(null);
@@ -66,9 +67,18 @@ export const ProductDetail = () => {
       try {
         if (res.statusCode === 200) {
           setProduct(res.data);
-          res.data.images.map((image) => {
-            console.log(image);
-          });
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    const fetchMyProductData = async () => {
+      const res2: AXIOSResponse<IProduct[]> = await getMyProduct();
+      try {
+        if (res2.statusCode === 200) {
+          setMyProduct(res2.data);
+          console.log(res2.data);
         }
       } catch (error) {
         console.error(error);
@@ -76,6 +86,7 @@ export const ProductDetail = () => {
     };
 
     fetchData();
+    fetchMyProductData();
 
     return () => {
       setProduct(null);
@@ -120,9 +131,9 @@ export const ProductDetail = () => {
         />
 
         <Slider className="product-detail__image-wrapper" {...settings}>
-          {product?.images.map((image) => {
+          {product?.images.map((image, index) => {
             return (
-              <div className="product-detail__image" key={image}>
+              <div className="product-detail__image" key={index}>
                 <img src={image} alt="" />
               </div>
             );
@@ -161,31 +172,20 @@ export const ProductDetail = () => {
           <div className="product-detail__more-product">
             <div>
               <div className="more-product__title">
-                <p>닉네임님의 판매상품</p>
+                <p>{product?.seller.nickname}님의 판매상품</p>
                 <Btn type="button" href="products" label="모두보기" />
               </div>
 
               <div className="more-product__grid">
-                <div className="more-product">
-                  <img src="/svg/cat.jpg" alt="cat" />
-                  <p>고양이는 귀엽다 고양이는 귀엽다 고양이는 귀엽다</p>
-                  <p>가격</p>
-                </div>
-                <div className="more-product">
-                  <img src="/svg/cat.jpg" alt="cat" />
-                  <p>고양이는 귀엽다</p>
-                  <p>가격</p>
-                </div>
-                <div className="more-product">
-                  <img src="/svg/cat.jpg" alt="cat" />
-                  <p>고양이는 귀엽다 고양이는 귀엽다 고양이는 귀엽다</p>
-                  <p>가격</p>
-                </div>
-                <div className="more-product">
-                  <img src="/svg/cat.jpg" alt="cat" />
-                  <p>고양이는 귀엽다</p>
-                  <p>가격</p>
-                </div>
+                {myProduct?.slice(0, 4).map((product, index) => {
+                  return (
+                    <div className="more-product" key={index}>
+                      <img src={product.thumbnail} alt="sale image" />
+                      <p>{product.title}</p>
+                      <p>{product.price}</p>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           </div>

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -2,7 +2,7 @@
 import Btn from '@/components/btn';
 import Header from '@/components/header';
 import '@/styles/templates/product/productDetail.scss';
-import Link from 'next/Link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { AiOutlineHeart } from 'react-icons/ai';
 import { BsThreeDotsVertical } from 'react-icons/bs';
@@ -13,6 +13,7 @@ import 'slick-carousel/slick/slick.css';
 export const ProductDetail = () => {
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const menuRef = useRef<HTMLUListElement | null>(null);
+  const router = useRouter();
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
@@ -72,7 +73,9 @@ export const ProductDetail = () => {
               />
               {isMenuOpen && (
                 <ul ref={menuRef} className="product-detail__menu">
-                  <li>게시글 수정</li>
+                  <li onClick={() => router.push('/product/edit')}>
+                    게시글 수정
+                  </li>
                   <li>삭제</li>
                 </ul>
               )}
@@ -86,13 +89,13 @@ export const ProductDetail = () => {
 
         <div className="product-detail__main">
           <div className="product-detail__profile">
-            <Link href={'/mypage'}>
+            <div onClick={() => router.push('/mypage')}>
               <img
                 src="/svg/default_profile.png"
                 alt="profile"
                 className="profile__image"
               />
-            </Link>
+            </div>
 
             <p className="profile__name">닉네임</p>
           </div>
@@ -165,9 +168,9 @@ export const ProductDetail = () => {
           <p>125만원</p>
         </div>
 
-        <Link href={'/chatList'}>
+        <div onClick={() => router.push('/chatList')}>
           <button className="product-detail__chat-button">관련 채팅보기</button>
-        </Link>
+        </div>
       </footer>
     </div>
   );

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -65,7 +65,6 @@ export const ProductDetail = () => {
       const res: AXIOSResponse<Product> = await getProductDetail(productId);
       try {
         if (res.statusCode === 200) {
-          console.log(res.data);
           setProduct(res.data);
           res.data.images.map((image) => {
             console.log(image);

--- a/src/templates/signup/signupPage.tsx
+++ b/src/templates/signup/signupPage.tsx
@@ -111,13 +111,27 @@ export default function SignupPage() {
         formData.phone,
         formData.nickname,
       );
-      console.log(res);
-      if (res.data.statusCode === 200) {
+      const statusCode = res.data.statusCode;
+      console.log(res.data);
+      if (res.status === 200) {
         alert('회원가입 성공!');
         router.push('/login');
+
+        // } else if (res.status === 400) {
+        // console.log('400 들어옴');
+        // if (statusCode === 401) {
+        //   console.log(statusCode);
+        //   alert('이미 가입된 이메일이 있습니다.');
+        // } else if (statusCode === 402) {
+        //   console.log(statusCode);
+        //   alert('이미 가입된 휴대폰 번호가 있습니다.');
+        // } else if (statusCode === 403) {
+        //   console.log(statusCode);
+        //   alert('이미 가입된 닉네임이 있습니다.');
       } else {
-        console.log(res.data.status);
+        console.log(res);
         alert('회원가입 실패');
+        // }
       }
     } else {
       alert('유효하지 않은 값을 입력하셨습니다.');

--- a/src/templates/signup/signupPage.tsx
+++ b/src/templates/signup/signupPage.tsx
@@ -105,31 +105,25 @@ export default function SignupPage() {
 
   const handleButtonClick = async () => {
     if (validateForm()) {
-      const res = await postSignUp(
-        formData.email,
-        formData.password,
-        formData.phone,
-        formData.nickname,
-      );
-      const statusCode = res.data.statusCode;
-      console.log(res.data);
-
-      if (res.status === 200) {
+      try {
+        const res = await postSignUp(
+          formData.email,
+          formData.password,
+          formData.phone,
+          formData.nickname,
+        );
+        console.log(res.data);
         alert('회원가입 성공!');
         router.push('/login');
-      } else if (res.status === 400) {
-        console.log('400 들어옴');
-        if (statusCode === 401) {
-          console.log(statusCode);
+      } catch (error: any) {
+        if (error.response.data.statusCode === 401) {
           alert('이미 가입된 이메일이 있습니다.');
-        } else if (statusCode === 402) {
-          console.log(statusCode);
+        } else if (error.response.data.statusCode === 402) {
           alert('이미 가입된 휴대폰 번호가 있습니다.');
-        } else if (statusCode === 403) {
-          console.log(statusCode);
+        } else if (error.response.data.statusCode === 403) {
           alert('이미 가입된 닉네임이 있습니다.');
         } else {
-          console.log(res);
+          console.log(error.response);
           alert('회원가입 실패');
         }
       }

--- a/src/templates/signup/signupPage.tsx
+++ b/src/templates/signup/signupPage.tsx
@@ -113,25 +113,25 @@ export default function SignupPage() {
       );
       const statusCode = res.data.statusCode;
       console.log(res.data);
+
       if (res.status === 200) {
         alert('회원가입 성공!');
         router.push('/login');
-
-        // } else if (res.status === 400) {
-        // console.log('400 들어옴');
-        // if (statusCode === 401) {
-        //   console.log(statusCode);
-        //   alert('이미 가입된 이메일이 있습니다.');
-        // } else if (statusCode === 402) {
-        //   console.log(statusCode);
-        //   alert('이미 가입된 휴대폰 번호가 있습니다.');
-        // } else if (statusCode === 403) {
-        //   console.log(statusCode);
-        //   alert('이미 가입된 닉네임이 있습니다.');
-      } else {
-        console.log(res);
-        alert('회원가입 실패');
-        // }
+      } else if (res.status === 400) {
+        console.log('400 들어옴');
+        if (statusCode === 401) {
+          console.log(statusCode);
+          alert('이미 가입된 이메일이 있습니다.');
+        } else if (statusCode === 402) {
+          console.log(statusCode);
+          alert('이미 가입된 휴대폰 번호가 있습니다.');
+        } else if (statusCode === 403) {
+          console.log(statusCode);
+          alert('이미 가입된 닉네임이 있습니다.');
+        } else {
+          console.log(res);
+          alert('회원가입 실패');
+        }
       }
     } else {
       alert('유효하지 않은 값을 입력하셨습니다.');


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#42 
## 작업 내용 (변경 사항)
* 상세 페이지 api 연결
* 내 판매내역 api 연결
   * 판매자의 판매내역이 아닌 로그인한 유저의 판매내역 -> api 생성 요청 필요
* 상품 id 값에 따른 동적 라우팅 구현
* 회원가입 에러처리 api 연결 
* Link 전부 router로 변경
## 스크린샷
<img width="242" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/111065848/a14cb1da-61b1-4028-9e34-c4aefcd6e322">
<img width="291" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/111065848/107714d2-b73b-481c-9ca9-6dea70f7ed96">
<img width="449" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/111065848/0b127b30-62fb-46a0-a7f9-f4e6c307fd41">



## 테스트 결과
* 메인 페이지에서 상품 클릭 시 상세 페이지로 이동. ('/product/[id]')
* 상세 데이터 렌더링
* 회원가입 이메일, 전화번호, 닉네임 중복 시 alert창 

## 리뷰 요청 사항

## Check list
- [ ] 테스트 통과
- [ ] 문서 업데이트
