### PR TITLE
Feature/#48 채팅 목록 구현, 단건 상품 수정

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -104,6 +104,8 @@ export const getMyProduct = async (pageSize: number) => {
   return res.data;
 };
 
+// 판매자의
+
 export const getMyChatList = async () => {
   const res = await client.get('/myPage/chats');
   return res.data;

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -99,7 +99,17 @@ export const getMyInfo = async () => {
 };
 
 // 내 판매 상품 리스트 조회
-export const getMyProduct = async () => {
-  const res = await client.get('/myPage/products');
+export const getMyProduct = async (pageSize: number) => {
+  const res = await client.get(`/myPage/products?pageSize=${pageSize}`);
+  return res.data;
+};
+
+export const getMyChatList = async () => {
+  const res = await client.get('/myPage/chats');
+  return res.data;
+};
+
+export const getProductChatList = async (id: number | null) => {
+  const res = await client.get(`/products/${id}/chats`);
   return res.data;
 };

--- a/src/app/mypage/chats/page.tsx
+++ b/src/app/mypage/chats/page.tsx
@@ -1,0 +1,5 @@
+import Chats from '@/templates/chat/chats';
+
+export default function Page() {
+  return <Chats />;
+}

--- a/src/app/product/[id]/chats/page.tsx
+++ b/src/app/product/[id]/chats/page.tsx
@@ -1,0 +1,5 @@
+import Chats from '@/templates/chat/chats';
+
+export default function Page() {
+  return <Chats />;
+}

--- a/src/styles/templates/chat/chats.scss
+++ b/src/styles/templates/chat/chats.scss
@@ -1,0 +1,36 @@
+#chat-list {
+  .chat-list {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #a5a5a5;
+    &__profile {
+      width: 3.2rem;
+      height: 3.2rem;
+      margin: 1rem;
+    }
+    &__content {
+      > p {
+        font-size: 1.2rem;
+        margin-top: 0.2rem;
+      }
+    }
+    &__desc {
+      color: #a5a5a5;
+      font-size: 0.8rem;
+    }
+    &__thumnail {
+      width: 3.6rem;
+      height: 3.6rem;
+      margin: 1rem;
+      > img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border: 1px solid black;
+        border-radius: 8px;
+        box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
+      }
+    }
+  }
+}

--- a/src/styles/templates/product/productDetail.scss
+++ b/src/styles/templates/product/productDetail.scss
@@ -29,7 +29,7 @@
       position: relative;
       top: -3.125rem;
       > select {
-        margin: 1rem;
+        margin: 1rem 0 0 1rem;
         padding: 0.2rem 0.6rem;
       }
     }
@@ -79,7 +79,7 @@
 
     &__title {
       font-size: 1.2rem;
-      margin-bottom: 1.2rem;
+      margin: 1.2rem 0;
     }
     &__description {
       display: flex;

--- a/src/templates/chat/chats.tsx
+++ b/src/templates/chat/chats.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { getMyChatList, getProductChatList } from '@/api/service';
+import Header from '@/components/header';
+import '@/styles/templates/chat/chats.scss';
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+export default function Chats() {
+  const [chats, setChats] = useState([]);
+
+  const path = usePathname();
+  const id: number | null = parseInt(path.split('/')[2]) || null;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = id ? await getProductChatList(id) : await getMyChatList();
+      if (res.statusCode === 200) {
+        setChats(res.data);
+      } else {
+        console.log(res);
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      setChats([]);
+    };
+  }, []);
+
+  console.log(chats);
+  return (
+    <>
+      <header>
+        <Header
+          goBack={true}
+          border={true}
+          title={id ? '이 상품 관련 채팅목록' : '채팅목록'}
+        />
+      </header>
+
+      <div id="chat-list">
+        <div className="chat-list">
+          <div>
+            <img
+              className="chat-list__profile"
+              src="/svg/default_profile.png"
+              alt="profile"
+            />
+          </div>
+          <div className="chat-list__content">
+            <div className="chat-list__desc">
+              <span>닉네임</span>
+              <span> | </span>
+              <span>장소</span>
+            </div>
+            <p>마지막 채팅 내용</p>
+          </div>
+          <div className="chat-list__thumnail">
+            <img src="/svg/cat.jpg" alt="thumnail" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -1,9 +1,9 @@
 'use client';
-import { getMyProduct, getProductDetail } from '@/api/service';
+import { getProductDetail } from '@/api/service';
 import Btn from '@/components/btn';
 import Header from '@/components/header';
 import '@/styles/templates/product/productDetail.scss';
-import { AXIOSResponse, IProduct } from '@/types/interface';
+import { AXIOSResponse } from '@/types/interface';
 import { useRouter, usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { AiOutlineHeart } from 'react-icons/ai';
@@ -18,6 +18,13 @@ type Seller = {
   nickname: string;
 };
 
+type sellerProductInfos = {
+  id: number;
+  price: number;
+  thumbnail: string;
+  title: string;
+};
+
 type Product = {
   id: number;
   title: string;
@@ -28,6 +35,7 @@ type Product = {
   status: string;
   likes: number;
   seller: Seller;
+  sellerProductInfos: sellerProductInfos[];
 };
 
 export const ProductDetail = () => {
@@ -39,7 +47,6 @@ export const ProductDetail = () => {
     typeof id === 'string' ? parseInt(id, 10) : undefined;
 
   const [product, setProduct] = useState<Product | null>(null);
-  const [myProduct, setMyProduct] = useState<IProduct[]>([]);
 
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const menuRef = useRef<HTMLUListElement | null>(null);
@@ -75,23 +82,11 @@ export const ProductDetail = () => {
       }
     };
 
-    const fetchMyProductData = async () => {
-      const res2: AXIOSResponse<IProduct[]> = await getMyProduct(4);
-      try {
-        if (res2.statusCode === 200) {
-          setMyProduct(res2.data);
-        }
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
     fetchData();
-    fetchMyProductData();
 
     return () => {
       setProduct(null);
-      setMyProduct([]);
+      [];
     };
   }, [id]);
 
@@ -181,7 +176,7 @@ export const ProductDetail = () => {
               </div>
 
               <div className="more-product__grid">
-                {myProduct?.map((product, index) => {
+                {product?.sellerProductInfos.map((product, index) => {
                   return (
                     <div
                       onClick={() => router.push(`/product/${product.id}`)}

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -34,6 +34,7 @@ type Product = {
   images: string[];
   status: string;
   likes: number;
+  myProduct: boolean;
   seller: Seller;
   sellerProductInfos: sellerProductInfos[];
 };
@@ -108,22 +109,24 @@ export const ProductDetail = () => {
           border={false}
           title=""
           button={
-            <>
-              <BsThreeDotsVertical
-                size="30"
-                background="#ccc"
-                className="product-detail__icon"
-                onClick={toggleMenu}
-              />
-              {isMenuOpen && (
-                <ul ref={menuRef} className="product-detail__menu">
-                  <li onClick={() => router.push('/product/edit')}>
-                    게시글 수정
-                  </li>
-                  <li>삭제</li>
-                </ul>
-              )}
-            </>
+            product?.myProduct && (
+              <>
+                <BsThreeDotsVertical
+                  size="30"
+                  background="#ccc"
+                  className="product-detail__icon"
+                  onClick={toggleMenu}
+                />
+                {isMenuOpen && (
+                  <ul ref={menuRef} className="product-detail__menu">
+                    <li onClick={() => router.push('/product/edit')}>
+                      게시글 수정
+                    </li>
+                    <li>삭제</li>
+                  </ul>
+                )}
+              </>
+            )
           }
         />
 
@@ -150,11 +153,13 @@ export const ProductDetail = () => {
             <p className="profile__name">{product?.seller.nickname}</p>
           </div>
 
-          <select>
-            <option>판매중</option>
-            <option>예약중</option>
-            <option>거래완료</option>
-          </select>
+          {product?.myProduct && (
+            <select>
+              <option>판매중</option>
+              <option>예약중</option>
+              <option>거래완료</option>
+            </select>
+          )}
 
           <div className="product-detail__content-wrapper">
             <p className="product-detail__title">{product?.title}</p>
@@ -168,29 +173,31 @@ export const ProductDetail = () => {
             <p className="product-detail__content">{product?.content}</p>
           </div>
 
-          <div className="product-detail__more-product">
-            <div>
-              <div className="more-product__title">
-                <p>{product?.seller.nickname}님의 판매상품</p>
-                <Btn type="button" href="products" label="모두보기" />
-              </div>
+          {product?.myProduct && (
+            <div className="product-detail__more-product">
+              <div>
+                <div className="more-product__title">
+                  <p>{product?.seller.nickname}님의 판매상품</p>
+                  <Btn type="button" href="products" label="모두보기" />
+                </div>
 
-              <div className="more-product__grid">
-                {product?.sellerProductInfos.map((product, index) => {
-                  return (
-                    <div
-                      onClick={() => router.push(`/product/${product.id}`)}
-                      className="more-product"
-                      key={index}>
-                      <img src={product.thumbnail} alt="sale image" />
-                      <p>{product.title}</p>
-                      <p>{product.price}</p>
-                    </div>
-                  );
-                })}
+                <div className="more-product__grid">
+                  {product?.sellerProductInfos.map((product, index) => {
+                    return (
+                      <div
+                        onClick={() => router.push(`/product/${product.id}`)}
+                        className="more-product"
+                        key={index}>
+                        <img src={product.thumbnail} alt="sale image" />
+                        <p>{product.title}</p>
+                        <p>{product.price}</p>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
 

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -173,7 +173,7 @@ export const ProductDetail = () => {
             <p className="product-detail__content">{product?.content}</p>
           </div>
 
-          {product?.myProduct && (
+          {!product?.myProduct && (
             <div className="product-detail__more-product">
               <div>
                 <div className="more-product__title">

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -22,7 +22,7 @@ type Product = {
   id: number;
   title: string;
   price: number;
-  categoryId: number;
+  categoryName: string;
   content: string;
   images: string[];
   status: string;
@@ -164,7 +164,9 @@ export const ProductDetail = () => {
           <div className="product-detail__content-wrapper">
             <p className="product-detail__title">{product?.title}</p>
             <div className="product-detail__description">
-              <p className="product-detail__category">{product?.categoryId}</p>
+              <p className="product-detail__category">
+                {product?.categoryName}
+              </p>
               <p className="product-detail__time">⋅ 1일 전</p>
             </div>
 

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -32,7 +32,8 @@ type Product = {
 
 export const ProductDetail = () => {
   const router = useRouter();
-  const id = usePathname().split('/')[2];
+  const path = usePathname();
+  const id = path.split('/')[2];
 
   const productId: number | any =
     typeof id === 'string' ? parseInt(id, 10) : undefined;
@@ -75,7 +76,7 @@ export const ProductDetail = () => {
     };
 
     const fetchMyProductData = async () => {
-      const res2: AXIOSResponse<IProduct[]> = await getMyProduct();
+      const res2: AXIOSResponse<IProduct[]> = await getMyProduct(4);
       try {
         if (res2.statusCode === 200) {
           setMyProduct(res2.data);
@@ -90,8 +91,10 @@ export const ProductDetail = () => {
 
     return () => {
       setProduct(null);
+      setMyProduct([]);
     };
   }, [id]);
+  console.log(myProduct);
 
   const settings = {
     dots: true, // 페이지 네비게이션(점) 표시
@@ -177,9 +180,12 @@ export const ProductDetail = () => {
               </div>
 
               <div className="more-product__grid">
-                {myProduct?.slice(0, 4).map((product, index) => {
+                {myProduct?.map((product, index) => {
                   return (
-                    <div className="more-product" key={index}>
+                    <div
+                      onClick={() => router.push(`/product/${product.id}`)}
+                      className="more-product"
+                      key={index}>
                       <img src={product.thumbnail} alt="sale image" />
                       <p>{product.title}</p>
                       <p>{product.price}</p>
@@ -199,7 +205,7 @@ export const ProductDetail = () => {
           <p>125만원</p>
         </div>
 
-        <div onClick={() => router.push('/chatList')}>
+        <div onClick={() => router.push(`/product/${id}/chats`)}>
           <button className="product-detail__chat-button">관련 채팅보기</button>
         </div>
       </footer>

--- a/src/templates/product/productDetail.tsx
+++ b/src/templates/product/productDetail.tsx
@@ -94,7 +94,6 @@ export const ProductDetail = () => {
       setMyProduct([]);
     };
   }, [id]);
-  console.log(myProduct);
 
   const settings = {
     dots: true, // 페이지 네비게이션(점) 표시


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#48 
## 작업 내용 (변경 사항)
* 채팅 목록 페이지 레이아웃 구성, 라우팅 설정
* path는 /mypage/chats 와 /product/[id]/chats 두 가지
    * path의 id 유무로 header 달라짐
* myPage/chats 와 products/{productId}/chats 두 가지 API를 연결 -> API가 완성되지 않아 빈 배열을 가져옴. 현재는 더미데이터.

* 상품 상세 페이지 수정
  * 판매자의 다른 판매 상품 클릭 시 상세 페이지로 이동
  * 상품 카테고리 타입 number -> string 수정
  * 판매글 게시자의 다른 판매 내역 조회
  * 판매글 작성자와 로그인한 유저가 같은 지 확인하여 다른 ui 제공
 
## 스크린샷
<img width="290" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/111065848/5f27a5a5-dde2-46e1-98cf-0e56cf521626">
<img width="291" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/111065848/31cf6aef-1177-4d46-ac1b-b5429fc48f14">
<img width="292" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/111065848/96bff612-6268-49ae-bbce-bdd72c7c94f5">
<img width="288" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/111065848/283663f6-6c48-4bf0-81f1-07a61c3864f8">

## 테스트 결과
* 상품 상세 페이지에서 채팅목록 버튼 클릭 시 채팅목록 페이지로 이동
* mypage/chats 로 이동 시 내 채팅목록 페이지로 이동
* 판매자의 다른 판매 상품 클릭 시 상세 페이지로 이동
* 판매글 게시자의 다른 판매 내역 조회
* 판매글 작성자와 로그인한 유저가 같은 지 확인하여 다른 ui 제공

## 리뷰 요청 사항

## Check list
- [ ] 테스트 통과
- [ ] 문서 업데이트
