### PR TITLE
Feature/#49 메인페이지 추가

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -94,8 +94,7 @@ export const updateProductState = async (
 
 export const getMyInfo = async () => {
   const res = await client.get('/myInfo');
-  console.log(res);
-  return res;
+  return res.data;
 };
 
 // 내 판매 상품 리스트 조회

--- a/src/components/productItem.tsx
+++ b/src/components/productItem.tsx
@@ -1,26 +1,28 @@
 import '@/styles/components/productItem.scss';
 import { IProduct } from '@/types/interface';
 import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
+import { useRouter } from 'next/navigation';
 
 export default function ProductItem({ product }: { product: IProduct }) {
-
+  const router = useRouter();
+  const onClick = () => {
+    router.push(`/product/${[product.id]}`);
+  };
   return (
-    <>
-      <li className="product">
-        <div className="product__img">
-          <img src={product.thumbnail} />
+    <li className="product" onClick={onClick}>
+      <div className="product__img">
+        <img src={product.thumbnail} />
+      </div>
+      <div className="product__content">
+        <div className="title">{product.title}</div>
+        <div className="price">{product.price}원</div>
+        <div className="like">
+          {product.like ? <AiFillHeart /> : <AiOutlineHeart />}
+          <p className="like__counter">
+            {product.likes > 0 ? product.likes : ' '}
+          </p>
         </div>
-        <div className="product__content">
-          <div className="title">{product.title}</div>
-          <div className="price">{product.price}원</div>
-          <div className="like">
-            {product.like ? <AiFillHeart /> : <AiOutlineHeart />}
-            <p className="like__counter">
-              {product.likes > 0 ? product.likes : ' '}
-            </p>
-          </div>
-        </div>
-      </li>
-    </>
+      </div>
+    </li>
   );
 }

--- a/src/components/productList.tsx
+++ b/src/components/productList.tsx
@@ -1,15 +1,11 @@
 import { IProduct } from '@/types/interface';
 import ProductItem from './productItem';
-import { useRouter } from 'next/navigation';
 
 export default function ProductList({ data }: { data: IProduct[] }) {
-  const router = useRouter();
   return (
     <ul className="products">
       {data?.map((product: IProduct) => (
-        <div onClick={() => router.push(`/product/${[product.id]}`)}>
-          <ProductItem key={product.id} product={product} />
-        </div>
+        <ProductItem key={product.id} product={product} />
       ))}
     </ul>
   );

--- a/src/styles/templates/category/category.scss
+++ b/src/styles/templates/category/category.scss
@@ -4,7 +4,7 @@
   .category {
     &__content {
       @include grid($gap: 0);
-      padding: 30px 20px 0;
+      padding: 0.8rem;
       div {
         @include flex($justify: center, $align: center);
         white-space: nowrap;

--- a/src/styles/templates/mypage/mypage.scss
+++ b/src/styles/templates/mypage/mypage.scss
@@ -1,0 +1,53 @@
+@import '@/styles/mixin';
+
+#mypagePage {
+  height: 100%;
+  .mypage-container {
+    @include flex($direction: column, $align: center);
+    margin: 1rem 0;
+    .user__info {
+      @include flex($direction: column, $align: center);
+      margin: 1rem;
+      width: 100%;
+      img {
+        $size: 8rem;
+        width: $size;
+        height: $size;
+        object-fit: cover;
+        background-color: #e2e2e2;
+        border-radius: 50%;
+      }
+      span {
+        margin: 1rem;
+      }
+      button {
+        padding: 0.8rem;
+        width: 18rem;
+      }
+    }
+    .link-group {
+      width: 100%;
+      padding: 0;
+      flex-grow: 0;
+      .option {
+        @include flex($justify: space-evenly, $align: center);
+        margin: 1rem 0;
+        font-size: 1rem;
+        color: #333;
+        .icon {
+          $size: 3rem;
+          width: $size;
+          height: $size;
+          padding: 0.5rem;
+          background-color: #e2e2e2;
+          border-radius: 50%;
+          svg {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/styles/templates/mypage/mypage.scss
+++ b/src/styles/templates/mypage/mypage.scss
@@ -19,6 +19,7 @@
       }
       span {
         margin: 1rem;
+        height: 1rem;
       }
       button {
         padding: 0.8rem;

--- a/src/templates/category/categoryPage.tsx
+++ b/src/templates/category/categoryPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getProductCategory, getProducts } from '@/api/service';
+import { getProductCategory } from '@/api/service';
 import Header from '@/components/header';
 import '@/styles/templates/category/category.scss';
 import { AXIOSResponse } from '@/types/interface';

--- a/src/templates/mypage/mypagePage.tsx
+++ b/src/templates/mypage/mypagePage.tsx
@@ -68,7 +68,7 @@ export default function MypagePage() {
           <div
             className="option"
             onClick={() => {
-              onClick('chat');
+              onClick('chats');
             }}>
             <div className="icon">
               <HiOutlineChatAlt2 />

--- a/src/templates/mypage/mypagePage.tsx
+++ b/src/templates/mypage/mypagePage.tsx
@@ -1,9 +1,83 @@
+'use client';
+
+import { getMyInfo } from '@/api/service';
+import Btn from '@/components/btn';
 import Header from '@/components/header';
+import Navbar from '@/components/navbar';
+import { AXIOSResponse, IUser } from '@/types/interface';
+import { useEffect, useState } from 'react';
+import { RiFileList3Line } from 'react-icons/ri';
+import { AiOutlineHeart } from 'react-icons/ai';
+import { HiOutlineChatAlt2 } from 'react-icons/hi';
+import '@/styles/templates/mypage/mypage.scss';
+import { useRouter } from 'next/navigation';
 
 export default function MypagePage() {
+  const [user, setUser] = useState<IUser>({
+    email: '',
+    nickname: '',
+    tel: '',
+    profileImage: '',
+  });
+  const router = useRouter();
+
+  const onClick = (option: string) => {
+    router.push(`/mypage/${option}`);
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const res: AXIOSResponse<IUser> = await getMyInfo();
+      if (res.statusCode === 200) {
+        setUser(res.data);
+      }
+    };
+    fetchData();
+  }, []);
+
   return (
     <div id="mypagePage">
       <Header title={'마이페이지'} border={true} />
+      <div className="mypage-container">
+        <div className="user__info">
+          <img src={user.profileImage} alt="유저 이미지" />
+          <span>{user.nickname}</span>
+          <Btn type="button" href="/mypage/edit" label="프로필수정" />
+        </div>
+        <div className="link-group">
+          <div
+            className="option"
+            onClick={() => {
+              onClick('sales');
+            }}>
+            <div className="icon">
+              <RiFileList3Line />
+            </div>
+            <span>판매내역</span>
+          </div>
+          <div
+            className="option"
+            onClick={() => {
+              onClick('wish');
+            }}>
+            <div className="icon">
+              <AiOutlineHeart />
+            </div>
+            <span>관심목록</span>
+          </div>
+          <div
+            className="option"
+            onClick={() => {
+              onClick('chat');
+            }}>
+            <div className="icon">
+              <HiOutlineChatAlt2 />
+            </div>
+            <span>채팅목록</span>
+          </div>
+        </div>
+      </div>
+      <Navbar />
     </div>
   );
 }

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -9,6 +9,14 @@ export interface IProduct {
   thumbnail: string;
 }
 
+// 유저
+export interface IUser {
+  email: string;
+  nickname: string;
+  tel: string;
+  profileImage: string;
+}
+
 // axios
 export interface AXIOSResponse<T> {
   statusCode: number;


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #49 
## 작업 내용 (변경 사항)
- 내정보 가져와서 프로필사진, 닉네임 보여주기
- 프로필 수정페이지(`/mypage/edit`)로 이동가능한 버튼 형성
- 내 판매 목록(`/mypage/sales`), 내 관심상품 목록(`/mypage/wish`), 내 채팅 목록 페이지(`/mypage/chat`)로 이동가능한 UI 생성
## 스크린샷
<img width="321" alt="image" src="https://github.com/EmploymentRescueTeam/FE_marketClone/assets/125979833/440a5b1d-cfe9-4bb0-b093-02b5a82af108">


## 테스트 결과

## 리뷰 요청 사항

## Check list
- [ ] 테스트 통과
- [ ] 문서 업데이트
